### PR TITLE
Version 2.3.26.0 of the AWS .NET SDK

### DIFF
--- a/AWS.Extensions/SessionProvider/Properties/AssemblyInfo.cs
+++ b/AWS.Extensions/SessionProvider/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.25.0")]
-[assembly: AssemblyFileVersion("2.3.25.0")]
+[assembly: AssemblyVersion("2.3.26.0")]
+[assembly: AssemblyFileVersion("2.3.26.0")]

--- a/AWS.Extensions/TraceListener/DynamoDBTraceListener.cs
+++ b/AWS.Extensions/TraceListener/DynamoDBTraceListener.cs
@@ -107,6 +107,7 @@ namespace Amazon.TraceListener
         private const int bufferSize = 0x1000; // 4 KB
         private static bool canWriteToEventLog;
         private static string eventLogSource = typeof(DynamoDBTraceListener).Name;
+        private static DynamoDBEntryConversion conversionSchema = DynamoDBEntryConversion.V1;
 
         private string _currentLogFile = null;
         private string CurrentLogFile
@@ -429,7 +430,7 @@ namespace Amazon.TraceListener
                 return null;
             }
 
-            Table table = Table.LoadTable(Client, Configuration.TableName);
+            Table table = Table.LoadTable(Client, Configuration.TableName, conversionSchema);
             return table;
         }
 
@@ -472,6 +473,8 @@ namespace Amazon.TraceListener
                 string message = ComposeMessage(data);
                 doc[ATTRIBUTE_MESSAGE] = LimitLength(message);
             }
+
+            doc = doc.ForceConversion(conversionSchema);
 
             // Set hash/range keys, possibly from event data
             doc[ATTRIBUTE_ORIGIN] = ExpandVariables(Configuration.HashKeyFormat, doc);

--- a/AWS.Extensions/TraceListener/Properties/AssemblyInfo.cs
+++ b/AWS.Extensions/TraceListener/Properties/AssemblyInfo.cs
@@ -38,5 +38,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.25.0")]
-[assembly: AssemblyFileVersion("2.3.25.0")]
+[assembly: AssemblyVersion("2.3.26.0")]
+[assembly: AssemblyFileVersion("2.3.26.0")]

--- a/AWSSDK_DotNet.IntegrationTests/Tests/S3/PutObjectTests.cs
+++ b/AWSSDK_DotNet.IntegrationTests/Tests/S3/PutObjectTests.cs
@@ -69,7 +69,7 @@ namespace AWSSDK_DotNet.IntegrationTests.Tests.S3
                 Console.WriteLine(exception.ErrorCode);
                 Console.WriteLine(exception.StatusCode);
 
-                Assert.AreEqual("The specified bucket does not exist", exception.Message);
+                Assert.IsTrue(exception.Message.Contains("The specified bucket does not exist"));
                 Assert.AreEqual("NoSuchBucket", exception.ErrorCode);
                 Assert.AreEqual(HttpStatusCode.NotFound, exception.StatusCode);
             }

--- a/AWSSDK_DotNet.UnitTests/AWSSDK_DotNet35.UnitTests.csproj
+++ b/AWSSDK_DotNet.UnitTests/AWSSDK_DotNet35.UnitTests.csproj
@@ -73,12 +73,14 @@
     <Compile Include="Runtime\RedirectHandlerTests.cs" />
     <Compile Include="Runtime\AmazonServiceClientTests.cs" />
     <Compile Include="Runtime\UnmarshallerTests.cs" />
+    <Compile Include="Runtime\UnparseableResponsesTests.cs" />
     <Compile Include="S3EventNotificationTests.cs" />
     <Compile Include="TestTools\Comparer.cs" />
     <Compile Include="TestTools\AWSQueryValidator.cs" />
     <Compile Include="TestTools\ComparerTests.cs" />
     <Compile Include="TestTools\Constants.cs" />
     <Compile Include="TestTools\CustomizationsTests.cs" />
+    <Compile Include="TestTools\DisposableSwitch.cs" />
     <Compile Include="TestTools\InstantiateClassGenerator.cs" />
     <Compile Include="TestTools\InstantiateClassGeneratorTests.cs" />
     <Compile Include="TestTools\JsonSampleGenerator.cs" />

--- a/AWSSDK_DotNet.UnitTests/Runtime/UnparseableResponsesTests.cs
+++ b/AWSSDK_DotNet.UnitTests/Runtime/UnparseableResponsesTests.cs
@@ -1,0 +1,305 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using System.IO;
+using AWSSDK_DotNet35.UnitTests;
+using Amazon.S3.Model;
+using Amazon.S3.Model.Internal.MarshallTransformations;
+using Amazon.Runtime.Internal.Util;
+using System.Threading;
+using System.Net;
+using Amazon.Runtime.Internal.Auth;
+using Amazon.Runtime.Internal;
+using Amazon.Runtime.Internal.Transform;
+using Amazon.S3;
+using Amazon;
+using Amazon.DynamoDBv2;
+using Amazon.Util;
+using AWSSDK_DotNet35.UnitTests.TestTools;
+using Amazon.Redshift;
+using ServiceClientGenerator;
+using System.Reflection;
+using Amazon.S3.Encryption;
+using System.Security.Cryptography;
+
+namespace AWSSDK.UnitTests
+{
+    [TestClass()]
+    public class UnparseableResponsesTests
+    {
+        // This test invokes all methods on most clients, testing how
+        // those clients are able to handle incorrect data
+        //[TestMethod]
+        public void TestAll()
+        {
+            LoadServices();
+
+            string requestId = null;
+
+            using (new DisableLogging())
+            {
+                TestAll(requestId);
+            }
+            TestAll(requestId);
+
+            requestId = "FakeRequestId123";
+            using (new DisableLogging())
+            {
+                TestAll(requestId);
+            }
+            TestAll(requestId);
+        }
+
+        private void TestAll(string requestId)
+        {
+            TestXmlServices(requestId);
+            TestJsonServices(requestId);
+        }
+
+        private List<Type> xmlServices = new List<Type>();
+        private List<Type> jsonServices = new List<Type>();
+        
+        private void LoadServices()
+        {
+            var manifestPath = @"..\..\..\_manifest.json";
+            var modelsFolder = @"..\..\..\ServiceModels";
+            var compileCustomizations = true;
+
+            if (compileCustomizations) // Compile all servicename.customizations*.json files into one json file in bin
+                CustomizationCompiler.CompileServiceCustomizations(modelsFolder);
+            var configs = ServiceClientGenerator.Program.LoadGeneratorConfigs(manifestPath, modelsFolder).ToList();
+            var baseClientType = typeof(AmazonServiceClient);
+
+            foreach(var config in configs)
+            {
+                var clientTypeName = config.Namespace + ".Amazon" + config.BaseName + "Client";
+                var clientType = baseClientType.Assembly.GetType(clientTypeName);
+                Assert.IsNotNull(clientType);
+
+                var protocol = config.ServiceModel.Type;
+                if (protocol == ServiceClientGenerator.ServiceType.Json ||
+                    protocol == ServiceClientGenerator.ServiceType.Rest_Json)
+                {
+                    jsonServices.Add(clientType);
+                }
+                else if (protocol == ServiceClientGenerator.ServiceType.Rest_Xml ||
+                    protocol == ServiceClientGenerator.ServiceType.Query)
+                {
+                    xmlServices.Add(clientType);
+                }
+                else
+                    throw new InvalidOperationException();
+            }
+        }
+
+        private void TestXmlServices(string requestId)
+        {
+            var clientTypes = xmlServices
+                .Except(new Type[] { typeof(Amazon.S3.AmazonS3Client), typeof(Amazon.SQS.AmazonSQSClient) })
+                .ToList();
+
+            TestServices(clientTypes, jsonResponse, requestId, isOK: true);
+            TestServices(clientTypes, jsonResponse, requestId, isOK: false);
+            TestServices(clientTypes, htmlResponse, requestId, isOK: true);
+            TestServices(clientTypes, htmlResponse, requestId, isOK: false);
+        }
+        private void TestJsonServices(string requestId)
+        {
+            var clientTypes = jsonServices
+                .Except(new Type[] { typeof(Amazon.CloudSearchDomain.AmazonCloudSearchDomainClient) })
+                .ToList();
+
+            TestServices(clientTypes, xmlResponse, requestId, isOK: true);
+            TestServices(clientTypes, xmlResponse, requestId, isOK: false);
+            TestServices(clientTypes, htmlResponse, requestId, isOK: true);
+            TestServices(clientTypes, htmlResponse, requestId, isOK: false);
+        }
+
+
+        private void TestServices(List<Type> clientTypes, string content, string requestId, bool isOK)
+        {
+            var baseClientType = typeof(AmazonServiceClient);
+
+            foreach(var clientType in clientTypes)
+            {
+                Console.WriteLine("Testing client {0}", clientType.FullName);
+
+                var clientObject = InstantiateClient(clientType);
+                var client = clientObject as AmazonServiceClient;
+                var requestMethods = GetValidRequestMethods(clientType);
+
+                using(client)
+                {
+                    SetResponse(client, Create(content, requestId, isOK));
+
+                    foreach (var requestMethod in requestMethods)
+                    {
+                        TestOperation(clientObject, requestMethod, content, requestId);
+                    }
+                }
+            }
+        }
+        private static void TestSingle(Type clientType, string methodName, string content, string requestId, bool isOK, object methodInput = null)
+        {
+            var clientObject = InstantiateClient(clientType);
+            var client = clientObject as AmazonServiceClient;
+
+            using (client)
+            {
+                SetResponse(client, Create(content, requestId, isOK));
+
+                var requestMethods = GetValidRequestMethods(clientType);
+                var requestMethod = requestMethods.First(m => m.Name.Equals(methodName, StringComparison.Ordinal));
+                TestOperation(clientObject, requestMethod, content, requestId, methodInput);
+            }
+        }
+
+        private static List<MethodInfo> GetValidRequestMethods(Type clientType)
+        {
+            var requestType = typeof(AmazonWebServiceRequest);
+            var requestMethods = clientType
+                .GetMethods()
+                .OrderBy(m => m.Name)
+                .Where(m =>
+                    m.GetParameters().Length == 1 &&
+                    m.GetParameters()[0].ParameterType.IsSubclassOf(requestType))
+                .ToList();
+            return requestMethods;
+        }
+
+        private static void TestOperation(object clientObject, MethodInfo requestMethod, string content, string requestId, object methodInput = null)
+        {
+            var name = requestMethod.Name;
+            Console.WriteLine("Calling {0}", name);
+
+            if (methodInput == null)
+            {
+                var inputType = requestMethod.GetParameters()[0].ParameterType;
+                methodInput = InstantiateClassGenerator.Execute(inputType);
+            }
+
+            VerifyAction(content, requestId, () => Invoke(clientObject, requestMethod, methodInput));
+        }
+
+        private static void VerifyAction(string content, string requestId, Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (AmazonUnmarshallingException aue)
+            {
+                // verify request id is correct. if not present, it is empty string
+                Assert.AreEqual(requestId ?? string.Empty, aue.RequestId);
+                if (!string.IsNullOrEmpty(requestId))
+                    Assert.IsTrue(aue.Message.Contains(requestId));
+                Assert.IsTrue(aue.Message.Contains(content));
+            }
+        }
+
+        private static void Invoke(object clientObject, System.Reflection.MethodInfo requestMethod, object input)
+        {
+            try
+            {
+                requestMethod.Invoke(clientObject, new object[] { input });
+            }
+            catch (System.Reflection.TargetInvocationException tie)
+            {
+                Assert.IsNotNull(tie);
+                Assert.IsNotNull(tie.InnerException);
+
+                var innerException = tie.InnerException;
+                PreserveStackTrace(innerException);
+                throw innerException;
+            }
+        }
+
+        private static void PreserveStackTrace(Exception exception)
+        {
+            var preserveStackTrace = typeof(Exception).GetMethod("InternalPreserveStackTrace",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            preserveStackTrace.Invoke(exception, null);
+        }
+
+        private static object InstantiateClient(Type clientType)
+        {
+            object inputObject = RegionEndpoint.USEast1;
+
+            // AmazonCloudSearchDomainClient has no RegionEndpoint constructor, so
+            // using its string constructor
+            if (clientType == typeof(Amazon.CloudSearchDomain.AmazonCloudSearchDomainClient))
+                inputObject = "http://www.amazon.com";
+
+            return Activator.CreateInstance(clientType, inputObject);
+        }
+
+        private const string xmlResponse = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<bookstore xmlns=""http://www.w3.org/2001/XMLSchema-instance"">
+    <book price=""25.50"" publicationdate=""2015-05-19"">
+        <title>Seveneves</title>
+        <author>
+            <first-name>Neal</first-name>
+            <last-name>Stephenson</last-name>
+        </author>
+        <genre>Science fiction</genre>
+    </book>
+</bookstore>";
+        private const string jsonResponse = @"{
+	""Books"":
+	[
+		""Cryptonomicon"", ""Seveneves""
+	]
+}";
+        private const string htmlResponse = @"<!DOCTYPE html>
+<html lang=""en-US"" xmlns=""http://www.w3.org/1999/xhtml"">
+<head> 
+	<meta http-equiv=""content-type"" content=""text/html; charset=UTF-8"" /> 
+</head> 
+<body> 
+	<div>
+		<p>Proxy error</p><br>
+		<p>Something happened, proxy at fault, whoops.</p>
+	</div>
+</body>
+</html>";
+
+        private static Func<HttpHandlerTests.MockHttpRequest, HttpWebResponse> Create(
+            string content, string requestId, bool isOK)
+        {
+            var status = isOK ? HttpStatusCode.OK : HttpStatusCode.NotFound;
+
+            return (request) =>
+            {
+                Dictionary<string,string> headers = new Dictionary<string, string>(StringComparer.Ordinal);
+                if (!string.IsNullOrEmpty(requestId))
+                    headers.Add(HeaderKeys.RequestIdHeader, requestId);
+
+                var response = MockWebResponse.Create(status, headers, content);
+                if (isOK)
+                    return response;
+
+                throw new HttpErrorResponseException(new HttpWebRequestResponseData(response));
+            };
+        }
+
+        public static void SetResponse(
+            AmazonServiceClient client,
+            Func<HttpHandlerTests.MockHttpRequest, HttpWebResponse> responseCreator)
+        {
+            var pipeline = client
+                .GetType()
+                .GetProperty("RuntimePipeline", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetValue(client, null)
+                as RuntimePipeline;
+
+            var requestFactory = new HttpHandlerTests.MockHttpRequestFactory();
+            requestFactory.ResponseCreator = responseCreator;
+            var httpHandler = new HttpHandler<Stream>(requestFactory, client);
+            pipeline.ReplaceHandler<HttpHandler<Stream>>(httpHandler);
+        }
+    }
+}

--- a/AWSSDK_DotNet.UnitTests/TestTools/DisposableSwitch.cs
+++ b/AWSSDK_DotNet.UnitTests/TestTools/DisposableSwitch.cs
@@ -1,0 +1,75 @@
+﻿using Amazon;
+using Amazon.Runtime;
+using System;
+
+namespace AWSSDK_DotNet35.UnitTests.TestTools
+{
+    /// <summary>
+    /// Simple way to switch between two states with a using block.
+    /// </summary>
+    public class DisposableSwitch : IDisposable
+    {
+        private bool CallbacksSet { get; set; }
+        private Action EndAction { get; set; }
+
+        public DisposableSwitch(Action onEnd)
+            : this(null, onEnd) { }
+        public DisposableSwitch(Action onStart, Action onEnd)
+        {
+            SetCallbacks(onStart, onEnd);
+        }
+
+        protected DisposableSwitch()
+        { }
+        protected void SetCallbacks(Action onStart, Action onEnd)
+        {
+            if (CallbacksSet)
+                throw new InvalidOperationException();
+
+            if (onStart != null)
+                onStart();
+            EndAction = onEnd;
+
+            CallbacksSet = true;
+        }
+
+        public void Dispose()
+        {
+            if (EndAction != null)
+                EndAction();
+        }
+    }
+
+    /// <summary>
+    /// Disables SDK logging while this object is not disposed
+    /// </summary>
+    public class DisableLogging : DisposableSwitch
+    {
+        public DisableLogging()
+            : base()
+        {
+            SetCallbacks(Disable, Enable);
+        }
+
+        private ResponseLoggingOption oldLogResponses;
+        private bool oldLogMetrics;
+        private LoggingOptions oldLogTo;
+        private void Disable()
+        {
+            oldLogResponses = AWSConfigs.LoggingConfig.LogResponses;
+            AWSConfigs.LoggingConfig.LogResponses = ResponseLoggingOption.Never;
+
+            oldLogMetrics = AWSConfigs.LoggingConfig.LogMetrics;
+            AWSConfigs.LoggingConfig.LogMetrics = false;
+
+            oldLogTo = AWSConfigs.LoggingConfig.LogTo;
+            AWSConfigs.LoggingConfig.LogTo = LoggingOptions.None;
+        }
+        private void Enable()
+        {
+            AWSConfigs.LoggingConfig.LogResponses = oldLogResponses;
+            AWSConfigs.LoggingConfig.LogMetrics = oldLogMetrics;
+            AWSConfigs.LoggingConfig.LogTo = oldLogTo;
+        }
+    }
+}

--- a/AWSSDK_DotNet.UnitTests/TestTools/InstantiateClassGenerator.cs
+++ b/AWSSDK_DotNet.UnitTests/TestTools/InstantiateClassGenerator.cs
@@ -19,15 +19,22 @@ namespace AWSSDK_DotNet35.UnitTests.TestTools
     /// </summary>
     public class InstantiateClassGenerator
     {
-        
-        public static T Execute<T>() where T : new()
+        public static T Execute<T>()
+            where T : new()
         {
-            var rootObject = new T();
+            var type = typeof(T);
+            var result = Execute(type);
+            var rootObject = (T)result;
+            return rootObject;
+        }
+
+        public static object Execute(Type type)
+        {
+            var rootObject = Activator.CreateInstance(type);
             TypeCircularReference<Type> tcr = new TypeCircularReference<Type>();
             InstantiateProperties(tcr, rootObject);
             return rootObject;
         }
-
 
         private static void InstantiateProperties(TypeCircularReference<Type> tcr, object owningObject)
         {
@@ -82,6 +89,10 @@ namespace AWSSDK_DotNet35.UnitTests.TestTools
                 {
                     return new MemoryStream(Constants.DEFAULT_BLOB);
                 }
+                //else if (type == typeof(Amazon.S3.S3Region))
+                //{
+                //    return Amazon.S3.S3Region.USW2; // S3 bucket region
+                //}
                 else if (type.BaseType.FullName == "Amazon.Runtime.ConstantClass")
                 {
                     var value = type.GetFields()[0].GetValue(null);
@@ -95,6 +106,22 @@ namespace AWSSDK_DotNet35.UnitTests.TestTools
                 {
                     return null; // Event Handlers
                 }
+                //else if (type.IsAssignableFrom(typeof(TimeSpan?)))
+                //{
+                //    return TimeSpan.FromHours(1); // S3 request timeout
+                //}
+                //else if (type == typeof(Amazon.S3.Model.ByteRange))
+                //{
+                //    return null; // s3 byte range
+                //}
+                //else if (type == typeof(Amazon.S3.Model.HeadersCollection))
+                //{
+                //    return null;
+                //}
+                //else if (type == typeof(Amazon.S3.Model.MetadataCollection))
+                //{
+                //    return null;
+                //}
                 else
                 {
                     var value = Activator.CreateInstance(type);

--- a/AWSSDK_DotNet.UnitTests/TestTools/MockWebResponse.cs
+++ b/AWSSDK_DotNet.UnitTests/TestTools/MockWebResponse.cs
@@ -12,7 +12,7 @@ namespace AWSSDK.UnitTests
 {
     public class MockWebResponse
     {
-        public static WebResponse CreateFromResource(string resourceName)
+        public static HttpWebResponse CreateFromResource(string resourceName)
         {
             var rawResponse = Utils.GetResourceText(resourceName);
 
@@ -22,7 +22,7 @@ namespace AWSSDK.UnitTests
             return Create(statusCode, response.Headers, response.Body);
         }
 
-        public static WebResponse Create(HttpStatusCode statusCode,
+        public static HttpWebResponse Create(HttpStatusCode statusCode,
             IDictionary<string,string> headers, string body = null)
         {
             var type = typeof(HttpWebResponse);
@@ -30,9 +30,12 @@ namespace AWSSDK.UnitTests
             var obj = assembly.CreateInstance("System.Net.HttpWebResponse");
 
             var webHeaders = new WebHeaderCollection();
-            foreach (var header in headers)
+            if (headers != null)
             {
-                webHeaders.Add(header.Key,header.Value);
+                foreach (var header in headers)
+                {
+                    webHeaders.Add(header.Key, header.Value);
+                }
             }
 
             Stream responseBodyStream = null;

--- a/AWSSDK_DotNet35/AWSConfigs.bcl.cs
+++ b/AWSSDK_DotNet35/AWSConfigs.bcl.cs
@@ -58,6 +58,13 @@ namespace Amazon
             return section as T;
         }
 
+        internal static bool XmlSectionExists(string sectionName)
+        {
+            var section = ConfigurationManager.GetSection(sectionName);
+            var element = section as System.Xml.XmlElement;
+            return (element != null);
+        }
+
         private static Dictionary<string, List<TraceListener>> _traceListeners
             = new Dictionary<string, List<TraceListener>>(StringComparer.OrdinalIgnoreCase);
 

--- a/AWSSDK_DotNet35/AWSSection.cs
+++ b/AWSSDK_DotNet35/AWSSection.cs
@@ -110,9 +110,9 @@ namespace Amazon
         }
 
         [ConfigurationProperty(correctForClockSkewKey)]
-        public bool CorrectForClockSkew
+        public bool? CorrectForClockSkew
         {
-            get { return (bool)this[correctForClockSkewKey]; }
+            get { return (bool?)this[correctForClockSkewKey]; }
             set { this[correctForClockSkewKey] = value; }
         }
 

--- a/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/AudioParameters.cs
+++ b/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/AudioParameters.cs
@@ -87,8 +87,8 @@ namespace Amazon.ElasticTranscoder.Model
         /// <summary>
         /// Gets and sets the property Codec. 
         /// <para>
-        /// The audio codec for the output file. Valid values include <code>aac</code>, <code>mp3</code>,
-        /// and <code>vorbis</code>.
+        /// The audio codec for the output file. Valid values include <code>aac</code>, <code>mp2</code>,
+        /// <code>mp3</code>, and <code>vorbis</code>.
         /// </para>
         /// </summary>
         public string Codec

--- a/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/CreatePresetRequest.cs
+++ b/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/CreatePresetRequest.cs
@@ -76,8 +76,9 @@ namespace Amazon.ElasticTranscoder.Model
         /// <summary>
         /// Gets and sets the property Container. 
         /// <para>
-        /// The container type for the output file. Valid values include <code>fmp4</code>, <code>mp3</code>,
-        /// <code>mp4</code>, <code>ogg</code>, <code>ts</code>, and <code>webm</code>.
+        /// The container type for the output file. Valid values include <code>flv</code>, <code>fmp4</code>,
+        /// <code>gif</code>, <code>mp3</code>, <code>mp4</code>, <code>mpg</code>, <code>ogg</code>,
+        /// <code>ts</code>, and <code>webm</code>.
         /// </para>
         /// </summary>
         public string Container

--- a/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/Internal/MarshallTransformations/JobOutputUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/Internal/MarshallTransformations/JobOutputUnmarshaller.cs
@@ -60,6 +60,12 @@ namespace Amazon.ElasticTranscoder.Model.Internal.MarshallTransformations
                     unmarshalledObject.AlbumArt = unmarshaller.Unmarshall(context);
                     continue;
                 }
+                if (context.TestExpression("AppliedColorSpaceConversion", targetDepth))
+                {
+                    var unmarshaller = StringUnmarshaller.Instance;
+                    unmarshalledObject.AppliedColorSpaceConversion = unmarshaller.Unmarshall(context);
+                    continue;
+                }
                 if (context.TestExpression("Captions", targetDepth))
                 {
                     var unmarshaller = CaptionsUnmarshaller.Instance;

--- a/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/JobOutput.cs
+++ b/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/JobOutput.cs
@@ -36,6 +36,7 @@ namespace Amazon.ElasticTranscoder.Model
     public partial class JobOutput
     {
         private JobAlbumArt _albumArt;
+        private string _appliedColorSpaceConversion;
         private Captions _captions;
         private List<Clip> _composition = new List<Clip>();
         private long? _duration;
@@ -69,6 +70,27 @@ namespace Amazon.ElasticTranscoder.Model
         internal bool IsSetAlbumArt()
         {
             return this._albumArt != null;
+        }
+
+        /// <summary>
+        /// Gets and sets the property AppliedColorSpaceConversion. 
+        /// <para>
+        /// If Elastic Transcoder used a preset with a <code>ColorSpaceConversionMode</code> to
+        /// transcode the output file, the <code>AppliedColorSpaceConversion</code> parameter
+        /// shows the conversion used. If no <code>ColorSpaceConversionMode</code> was defined
+        /// in the preset, this parameter will not be included in the job response.
+        /// </para>
+        /// </summary>
+        public string AppliedColorSpaceConversion
+        {
+            get { return this._appliedColorSpaceConversion; }
+            set { this._appliedColorSpaceConversion = value; }
+        }
+
+        // Check to see if AppliedColorSpaceConversion property is set
+        internal bool IsSetAppliedColorSpaceConversion()
+        {
+            return this._appliedColorSpaceConversion != null;
         }
 
         /// <summary>

--- a/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/Preset.cs
+++ b/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/Preset.cs
@@ -85,8 +85,9 @@ namespace Amazon.ElasticTranscoder.Model
         /// <summary>
         /// Gets and sets the property Container. 
         /// <para>
-        /// The container type for the output file. Valid values include <code>fmp4</code>, <code>mp3</code>,
-        /// <code>mp4</code>, <code>ogg</code>, <code>ts</code>, and <code>webm</code>.
+        /// The container type for the output file. Valid values include <code>flv</code>, <code>fmp4</code>,
+        /// <code>gif</code>, <code>mp3</code>, <code>mp4</code>, <code>mpg</code>, <code>ogg</code>,
+        /// <code>ts</code>, and <code>webm</code>.
         /// </para>
         /// </summary>
         public string Container

--- a/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/VideoParameters.cs
+++ b/AWSSDK_DotNet35/Amazon.ElasticTranscoder/Model/VideoParameters.cs
@@ -125,8 +125,10 @@ namespace Amazon.ElasticTranscoder.Model
         /// <summary>
         /// Gets and sets the property Codec. 
         /// <para>
-        /// The video codec for the output file. Valid values include <code>H.264</code> and <code>vp8</code>.
-        /// You can only specify <code>vp8</code> when the container type is <code>webm</code>.
+        /// The video codec for the output file. Valid values include <code>gif</code>, <code>H.264</code>,
+        /// <code>mpeg2</code>, and <code>vp8</code>. You can only specify <code>vp8</code> when
+        /// the container type is <code>webm</code>, <code>gif</code> when the container type
+        /// is <code>gif</code>, and <code>mpeg2</code> when the container type is <code>mpg</code>.
         /// </para>
         /// </summary>
         public string Codec
@@ -144,7 +146,7 @@ namespace Amazon.ElasticTranscoder.Model
         /// <summary>
         /// Gets and sets the property CodecOptions. 
         /// <para>
-        ///  <b>Profile</b> 
+        ///  <b>Profile (H.264/VP8 Only)</b> 
         /// </para>
         ///  
         /// <para>
@@ -197,7 +199,7 @@ namespace Amazon.ElasticTranscoder.Model
         /// <li>3.1 - 18000</li> <li>3.2 - 20480</li> <li>4 - 32768</li> <li>4.1 - 32768</li>
         /// </ul> 
         /// <para>
-        ///  <b>MaxBitRate</b> 
+        ///  <b>MaxBitRate (Optional, H.264/MPEG2/VP8 only)</b> 
         /// </para>
         ///  
         /// <para>
@@ -208,7 +210,7 @@ namespace Amazon.ElasticTranscoder.Model
         /// </para>
         ///  
         /// <para>
-        ///  <b>BufferSize</b> 
+        ///  <b>BufferSize (Optional, H.264/MPEG2/VP8 only)</b> 
         /// </para>
         ///  
         /// <para>
@@ -217,6 +219,96 @@ namespace Amazon.ElasticTranscoder.Model
         /// container type of the output video. Specify an integer greater than 0. If you specify
         /// <code>MaxBitRate</code> and omit <code>BufferSize</code>, Elastic Transcoder sets
         /// <code>BufferSize</code> to 10 times the value of <code>MaxBitRate</code>.
+        /// </para>
+        ///  
+        /// <para>
+        ///  <b>InterlacedMode (Optional, H.264/MPEG2 Only)</b> 
+        /// </para>
+        ///  
+        /// <para>
+        /// The interlace mode for the output video.
+        /// </para>
+        ///  
+        /// <para>
+        /// Interlaced video is used to double the perceived frame rate for a video by interlacing
+        /// two fields (one field on every other line, the other field on the other lines) so
+        /// that the human eye registers multiple pictures per frame. Interlacing reduces the
+        /// bandwidth required for transmitting a video, but can result in blurred images and
+        /// flickering.
+        /// </para>
+        ///  
+        /// <para>
+        /// Valid values include <code>Progressive</code> (no interlacing, top to bottom), <code>TopFirst</code>
+        /// (top field first), <code>BottomFirst</code> (bottom field first), and <code>Auto</code>.
+        /// </para>
+        ///  
+        /// <para>
+        /// If <code>InterlaceMode</code> is not specified, Elastic Transcoder uses <code>Progressive</code>
+        /// for the output. If <code>Auto</code> is specified, Elastic Transcoder interlaces the
+        /// output.
+        /// </para>
+        ///  
+        /// <para>
+        ///  <b>ColorSpaceConversionMode (Optional, H.264/MPEG2 Only)</b> 
+        /// </para>
+        ///  
+        /// <para>
+        /// The color space conversion Elastic Transcoder applies to the output video. Color spaces
+        /// are the algorithms used by the computer to store information about how to render color.
+        /// <code>Bt.601</code> is the standard for standard definition video, while <code>Bt.709</code>
+        /// is the standard for high definition video.
+        /// </para>
+        ///  
+        /// <para>
+        /// Valid values include <code>None</code>, <code>Bt709toBt601</code>, <code>Bt601toBt709</code>,
+        /// and <code>Auto</code>.
+        /// </para>
+        ///  
+        /// <para>
+        /// If you chose <code>Auto</code> for <code>ColorSpaceConversionMode</code> and your
+        /// output is interlaced, your frame rate is one of <code>23.97</code>, <code>24</code>,
+        /// <code>25</code>, <code>29.97</code>, <code>50</code>, or <code>60</code>, your <code>SegmentDuration</code>
+        /// is null, and you are using one of the resolution changes from the list below, Elastic
+        /// Transcoder applies the following color space conversions:
+        /// </para>
+        ///  <ul> <li> <i>Standard to HD, 720x480 to 1920x1080</i> - Elastic Transcoder applies
+        /// <code>Bt601ToBt709</code> </li> <li> <i>Standard to HD, 720x576 to 1920x1080</i> -
+        /// Elastic Transcoder applies <code>Bt601ToBt709</code> </li> <li> <i>HD to Standard,
+        /// 1920x1080 to 720x480</i> - Elastic Transcoder applies <code>Bt709ToBt601</code> </li>
+        /// <li> <i>HD to Standard, 1920x1080 to 720x576</i> - Elastic Transcoder applies <code>Bt709ToBt601</code>
+        /// </li> </ul> <note>Elastic Transcoder may change the behavior of the <code>ColorspaceConversionMode</code>
+        /// <code>Auto</code> mode in the future. All outputs in a playlist must use the same
+        /// <code>ColorSpaceConversionMode</code>.</note> 
+        /// <para>
+        /// If you do not specify a <code>ColorSpaceConversionMode</code>, Elastic Transcoder
+        /// does not change the color space of a file. If you are unsure what <code>ColorSpaceConversionMode</code>
+        /// was applied to your output file, you can check the <code>AppliedColorSpaceConversion</code>
+        /// parameter included in your job response. If your job does not have an <code>AppliedColorSpaceConversion</code>
+        /// in its response, no <code>ColorSpaceConversionMode</code> was applied.
+        /// </para>
+        ///  
+        /// <para>
+        ///  <b>ChromaSubsampling</b> 
+        /// </para>
+        ///  
+        /// <para>
+        /// The sampling pattern for the chroma (color) channels of the output video. Valid values
+        /// include <code>yuv420p</code> and <code>yuv422p</code>.
+        /// </para>
+        ///  
+        /// <para>
+        /// <code>yuv420p</code> samples the chroma information of every other horizontal and
+        /// every other vertical line, <code>yuv422p</code> samples the color information of every
+        /// horizontal line and every other vertical line.
+        /// </para>
+        ///  
+        /// <para>
+        ///  <b>LoopCount (Gif Only)</b> 
+        /// </para>
+        ///  
+        /// <para>
+        /// The number of times you want the output gif to loop. Valid values include <code>Infinite</code>
+        /// and integers between <code>0</code> and <code>100</code>, inclusive.
         /// </para>
         /// </summary>
         public Dictionary<string, string> CodecOptions
@@ -251,6 +343,11 @@ namespace Amazon.ElasticTranscoder.Model
 
         /// <summary>
         /// Gets and sets the property FixedGOP. 
+        /// <para>
+        /// Applicable only when the value of Video:Codec is one of <code>H.264</code>, <code>MPEG2</code>,
+        /// or <code>VP8</code>.
+        /// </para>
+        ///  
         /// <para>
         /// Whether to use a fixed value for <code>FixedGOP</code>. Valid values are <code>true</code>
         /// and <code>false</code>:
@@ -328,6 +425,11 @@ namespace Amazon.ElasticTranscoder.Model
 
         /// <summary>
         /// Gets and sets the property KeyframesMaxDist. 
+        /// <para>
+        /// Applicable only when the value of Video:Codec is one of <code>H.264</code>, <code>MPEG2</code>,
+        /// or <code>VP8</code>.
+        /// </para>
+        ///  
         /// <para>
         /// The maximum number of frames between key frames. Key frames are fully encoded frames;
         /// the frames between key frames are encoded based, in part, on the content of the key

--- a/AWSSDK_DotNet35/Amazon.Runtime/AmazonUnmarshallingException.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/AmazonUnmarshallingException.cs
@@ -23,7 +23,7 @@ namespace Amazon.Runtime
     /// </summary>
     public class AmazonUnmarshallingException : AmazonServiceException
     {
-        private string lastKnownLocation;
+        #region Constructors
 
         public AmazonUnmarshallingException(string requestId, string lastKnownLocation, Exception innerException)
             : base("Error unmarshalling response back from AWS.", innerException)
@@ -31,25 +31,63 @@ namespace Amazon.Runtime
             this.RequestId = requestId;
             this.LastKnownLocation = lastKnownLocation;
         }
-
-        public string LastKnownLocation
+        public AmazonUnmarshallingException(string requestId, string lastKnownLocation, string responseBody, Exception innerException)
+            : base("Error unmarshalling response back from AWS.", innerException)
         {
-            get { return this.lastKnownLocation; }
-            private set { this.lastKnownLocation = value; }
+            this.RequestId = requestId;
+            this.LastKnownLocation = lastKnownLocation;
+            this.ResponseBody = responseBody;
         }
+
+        #endregion
+
+        #region Public properties
+
+        /// <summary>
+        /// Last known location in the response that was parsed, if available.
+        /// </summary>
+        public string LastKnownLocation { get; private set; }
+
+        /// <summary>
+        /// The entire response body that caused this exception, if available.
+        /// </summary>
+        public string ResponseBody { get; private set; }
+
+        #endregion
+
+        #region Overrides
 
         public override string Message
         {
             get
             {
                 StringBuilder sb = new StringBuilder();
-                if (!string.IsNullOrEmpty(this.RequestId))
-                    sb.AppendFormat("Request ID: {0}", this.RequestId);
-                if (!string.IsNullOrEmpty(this.LastKnownLocation))
-                    sb.AppendFormat(", Last Parsed Path: {0}", this.LastKnownLocation);
 
-                return base.Message + " " + sb.ToString();
+                AppendFormat(sb, "Request ID: {0}", this.RequestId);
+                AppendFormat(sb, "Response Body: {0}", this.ResponseBody);
+                AppendFormat(sb, "Last Parsed Path: {0}", this.LastKnownLocation);
+
+                var partialMessage = sb.ToString();
+
+                return base.Message + " " + partialMessage;
             }
         }
+
+        #endregion
+
+        #region Private methods
+
+        private static void AppendFormat(StringBuilder sb, string format, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            if (sb.Length > 0)
+                sb.Append(", ");
+
+            sb.AppendFormat(format, value);
+        }
+
+        #endregion
     }
 }

--- a/AWSSDK_DotNet35/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/Internal/Transform/UnmarshallerContext.cs
@@ -266,6 +266,13 @@ namespace Amazon.Runtime.Internal.Transform
 #else
         private static readonly XmlReaderSettings READER_SETTINGS = new XmlReaderSettings() { DtdProcessing = DtdProcessing.Ignore, IgnoreWhitespace = true };
 #endif
+        private static HashSet<XmlNodeType> nodesToSkip = new HashSet<XmlNodeType>
+        {
+            XmlNodeType.None,
+            XmlNodeType.XmlDeclaration,
+            XmlNodeType.Comment,
+            XmlNodeType.DocumentType
+        };
 
         private StreamReader streamReader;
         private XmlReader _xmlReader;
@@ -356,7 +363,8 @@ namespace Amazon.Runtime.Internal.Transform
             }
             else
             {
-                if (XmlReader.NodeType == XmlNodeType.None || XmlReader.NodeType == XmlNodeType.XmlDeclaration || XmlReader.NodeType == XmlNodeType.Comment)
+                // Skip some nodes
+                if (nodesToSkip.Contains(XmlReader.NodeType))
                     XmlReader.Read();
 
                 while (XmlReader.IsEmptyElement)

--- a/AWSSDK_DotNet35/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/Internal/Util/Logger.Log4net.cs
@@ -115,8 +115,12 @@ namespace Amazon.Runtime.Internal.Util
                         return;
                     }
 
-                    // If log4net logging is enabled, we attempt to activate log4net by calling XmlConfigurator.Configure()
-                    if ((AWSConfigs.LoggingConfig.LogTo & LoggingOptions.Log4Net) == LoggingOptions.Log4Net)
+                    var log4netSectionPresent = AWSConfigs.XmlSectionExists("log4net");
+
+                    // If log4net section exists and log4net logging is enabled, we attempt to activate
+                    // log4net by calling XmlConfigurator.Configure()
+                    if (log4netSectionPresent &&
+                        (AWSConfigs.LoggingConfig.LogTo & LoggingOptions.Log4Net) == LoggingOptions.Log4Net)
                     {
                         ITypeInfo xmlConfiguratorType = TypeFactory.GetTypeInfo(Type.GetType("log4net.Config.XmlConfigurator, log4net"));
                         if (xmlConfiguratorType != null)

--- a/AWSSDK_DotNet35/Amazon.Runtime/Internal/Util/Metrics.cs
+++ b/AWSSDK_DotNet35/Amazon.Runtime/Internal/Util/Metrics.cs
@@ -371,13 +371,17 @@ namespace Amazon.Runtime.Internal.Util
             foreach (var kvp in this.Properties)
             {
                 jw.WritePropertyName(kvp.Key.ToString());
-                if (kvp.Value.Count > 1)
+                var properties = kvp.Value;
+                if (properties.Count > 1)
                     jw.WriteArrayStart();
-                foreach (var obj in kvp.Value)
+                foreach (var obj in properties)
                 {
-                    jw.Write(obj.ToString());
+                    if (obj == null)
+                        jw.Write(null);
+                    else
+                        jw.Write(obj.ToString());
                 }
-                if (kvp.Value.Count > 1)
+                if (properties.Count > 1)
                     jw.WriteArrayEnd();
             }
             jw.WriteObjectEnd();
@@ -386,7 +390,7 @@ namespace Amazon.Runtime.Internal.Util
             foreach (var kvp in this.Timings)
             {
                 jw.WritePropertyName(kvp.Key.ToString());
-                List<Amazon.Runtime.IMetricsTiming> timings = kvp.Value;
+                var timings = kvp.Value;
                 if (timings.Count > 1)
                     jw.WriteArrayStart();
                 foreach (var timing in kvp.Value)

--- a/AWSSDK_DotNet35/Amazon.S3/AmazonS3Exception.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/AmazonS3Exception.cs
@@ -59,5 +59,24 @@ namespace Amazon.S3
         /// </summary>
         public string AmazonId2 { get; protected set; }
 
+        /// <summary>
+        /// The entire response body for this exception, if available.
+        /// </summary>
+        public string ResponseBody { get; internal set; }
+
+        #region Overrides
+
+        public override string Message
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(ResponseBody))
+                    return base.Message;
+                else
+                    return base.Message + " " + "Response Body: " + ResponseBody;
+            }
+        }
+
+        #endregion
     }
 }

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/AbortMultipartUploadResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/AbortMultipartUploadResponseUnmarshaller.cs
@@ -35,15 +35,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static AbortMultipartUploadResponseUnmarshaller _instance;
 
         public static AbortMultipartUploadResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/CompleteMultipartUploadResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/CompleteMultipartUploadResponseUnmarshaller.cs
@@ -102,13 +102,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static CompleteMultipartUploadResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/CopyObjectResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/CopyObjectResponseUnmarshaller.cs
@@ -90,13 +90,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static CopyObjectResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/CopyPartResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/CopyPartResponseUnmarshaller.cs
@@ -88,13 +88,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static CopyPartResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketCorsResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketCorsResponseUnmarshaller.cs
@@ -25,7 +25,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
     /// <summary>
     ///    Response Unmarshaller for DeleteCORSConfiguration operation
     /// </summary>
-    internal class DeleteCORSConfigurationResponseUnmarshaller : XmlResponseUnmarshaller
+    internal class DeleteCORSConfigurationResponseUnmarshaller : S3ReponseUnmarshaller
     {
 
         public override AmazonWebServiceResponse Unmarshall(XmlUnmarshallerContext context) 
@@ -34,14 +34,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
             
 
             return response;
-        }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
         }
 
         private static DeleteCORSConfigurationResponseUnmarshaller _instance;

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketPolicyResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketPolicyResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }      
 
         private static DeleteBucketPolicyResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static DeleteBucketResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketTaggingResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketTaggingResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static DeleteBucketTaggingResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketWebsiteResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteBucketWebsiteResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static DeleteBucketWebsiteResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteLifecycleConfigurationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteLifecycleConfigurationResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static DeleteLifecycleConfigurationResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteObjectResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteObjectResponseUnmarshaller.cs
@@ -50,14 +50,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static DeleteObjectResponseUnmarshaller _instance;
 
         public static DeleteObjectResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteObjectsResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/DeleteObjectsResponseUnmarshaller.cs
@@ -80,14 +80,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static DeleteObjectsResponseUnmarshaller _instance;
 
         public static DeleteObjectsResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetACLResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetACLResponseUnmarshaller.cs
@@ -84,13 +84,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetACLResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketLocationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketLocationResponseUnmarshaller.cs
@@ -64,14 +64,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static GetBucketLocationResponseUnmarshaller _instance;
 
         public static GetBucketLocationResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketLoggingResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketLoggingResponseUnmarshaller.cs
@@ -74,13 +74,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetBucketLoggingResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketNotificationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketNotificationResponseUnmarshaller.cs
@@ -81,14 +81,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static GetBucketNotificationResponseUnmarshaller _instance;
 
         public static GetBucketNotificationResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketPolicyResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketPolicyResponseUnmarshaller.cs
@@ -48,13 +48,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetBucketPolicyResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketRequestPaymentResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketRequestPaymentResponseUnmarshaller.cs
@@ -74,13 +74,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetBucketRequestPaymentResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketTaggingResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketTaggingResponseUnmarshaller.cs
@@ -74,13 +74,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetBucketTaggingResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketVersioningResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketVersioningResponseUnmarshaller.cs
@@ -63,7 +63,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                             
                         continue;
                     }
-                    if (context.TestExpression("MFADelete", targetDepth))
+                    if (context.TestExpression("MfaDelete", targetDepth))
                     {
                         response.VersioningConfig.EnableMfaDelete = string.Equals(StringUnmarshaller.GetInstance().Unmarshall(context), "Enabled");
                             
@@ -79,13 +79,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
 
             return;
-        }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
         }
 
         private static GetBucketVersioningResponseUnmarshaller _instance;

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketWebsiteResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetBucketWebsiteResponseUnmarshaller.cs
@@ -93,13 +93,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetBucketWebsiteResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetCORSConfigurationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetCORSConfigurationResponseUnmarshaller.cs
@@ -77,13 +77,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetCORSConfigurationResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetLifecycleConfigurationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetLifecycleConfigurationResponseUnmarshaller.cs
@@ -74,13 +74,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static GetLifecycleConfigurationResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetObjectMetadataResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetObjectMetadataResponseUnmarshaller.cs
@@ -98,14 +98,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static GetObjectMetadataResponseUnmarshaller _instance;
 
         public static GetObjectMetadataResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetObjectResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetObjectResponseUnmarshaller.cs
@@ -104,14 +104,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         {
            get { return true;}
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-            
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
+
         private static GetObjectResponseUnmarshaller _instance;
 
         public static GetObjectResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetObjectTorrentResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/GetObjectTorrentResponseUnmarshaller.cs
@@ -51,14 +51,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         {
            get { return true;}
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static GetObjectTorrentResponseUnmarshaller _instance;
 
         public static GetObjectTorrentResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/HeadBucketResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/HeadBucketResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static HeadBucketResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/InitiateMultipartUploadResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/InitiateMultipartUploadResponseUnmarshaller.cs
@@ -92,14 +92,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static InitiateMultipartUploadResponseUnmarshaller _instance;
 
         public static InitiateMultipartUploadResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListBucketsResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListBucketsResponseUnmarshaller.cs
@@ -80,13 +80,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static ListBucketsResponseUnmarshaller _instance = new ListBucketsResponseUnmarshaller();
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListMultipartUploadsResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListMultipartUploadsResponseUnmarshaller.cs
@@ -135,14 +135,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static ListMultipartUploadsResponseUnmarshaller _instance;
 
         public static ListMultipartUploadsResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListObjectsResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListObjectsResponseUnmarshaller.cs
@@ -119,14 +119,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static ListObjectsResponseUnmarshaller _instance;
 
         public static ListObjectsResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListPartsResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListPartsResponseUnmarshaller.cs
@@ -134,14 +134,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static ListPartsResponseUnmarshaller _instance;
 
         public static ListPartsResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListVersionsResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/ListVersionsResponseUnmarshaller.cs
@@ -145,14 +145,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static ListVersionsResponseUnmarshaller _instance;
 
         public static ListVersionsResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutACLResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutACLResponseUnmarshaller.cs
@@ -34,14 +34,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutACLResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketLoggingResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketLoggingResponseUnmarshaller.cs
@@ -35,15 +35,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static PutBucketLoggingResponseUnmarshaller _instance;
 
         public static PutBucketLoggingResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketNotificationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketNotificationResponseUnmarshaller.cs
@@ -35,15 +35,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static PutBucketNotificationResponseUnmarshaller _instance;
 
         public static PutBucketNotificationResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketPolicyResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketPolicyResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutBucketPolicyResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketRequestPaymentResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketRequestPaymentResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutBucketRequestPaymentResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketResponseUnmarshaller.cs
@@ -25,33 +25,20 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
     /// <summary>
     ///    Response Unmarshaller for PutBucket operation
     /// </summary>
-    internal class PutBucketResponseUnmarshaller : XmlResponseUnmarshaller
+    internal class PutBucketResponseUnmarshaller : S3ReponseUnmarshaller
     {
         public override AmazonWebServiceResponse Unmarshall(XmlUnmarshallerContext context) 
         {   
             PutBucketResponse response = new PutBucketResponse();
             
-            UnmarshallResult(context,response);                        
-                 
-                        
+            UnmarshallResult(context,response);
+
             return response;
         }
         
         private static void UnmarshallResult(XmlUnmarshallerContext context,PutBucketResponse response)
         {
-            
-
-  
-
-
             return;
-        }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
         }
 
         private static PutBucketResponseUnmarshaller _instance;

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketTaggingResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketTaggingResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutBucketTaggingResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketVersioningRequestMarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketVersioningRequestMarshaller.cs
@@ -56,7 +56,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                     xmlWriter.WriteStartElement("VersioningConfiguration", "");
                     if (versioningConfigurationVersioningConfiguration.IsSetEnableMfaDelete())
                     {
-                        xmlWriter.WriteElementString("MFADelete", "", versioningConfigurationVersioningConfiguration.EnableMfaDelete ? "Enabled" : "Disabled");
+                        xmlWriter.WriteElementString("MfaDelete", "", versioningConfigurationVersioningConfiguration.EnableMfaDelete ? "Enabled" : "Disabled");
                     }
                     if (versioningConfigurationVersioningConfiguration.IsSetStatus())
                     {

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketVersioningResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketVersioningResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutBucketVersioningResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketWebsiteResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutBucketWebsiteResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutBucketWebsiteResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutCORSConfigurationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutCORSConfigurationResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutCORSConfigurationResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutLifecycleConfigurationResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutLifecycleConfigurationResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutLifecycleConfigurationResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutObjectResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/PutObjectResponseUnmarshaller.cs
@@ -56,13 +56,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static PutObjectResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/RestoreObjectResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/RestoreObjectResponseUnmarshaller.cs
@@ -35,14 +35,6 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return response;
         }
-        
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
-
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
 
         private static RestoreObjectResponseUnmarshaller _instance;
 

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/S3ErrorResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/S3ErrorResponseUnmarshaller.cs
@@ -19,6 +19,7 @@ using Amazon.Util;
 using Amazon.S3.Util;
 using Amazon.Runtime.Internal.Transform;
 using Amazon.Runtime;
+using System;
 
 namespace Amazon.S3.Model.Internal.MarshallTransformations
 {
@@ -37,15 +38,16 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
         {
             S3ErrorResponse response = new S3ErrorResponse();
 
-            response.Code = context.ResponseData.StatusCode.ToString();
+            var statusCode = context.ResponseData.StatusCode;
+            response.Code = statusCode.ToString();
             if (context.ResponseData.IsHeaderPresent(HeaderKeys.XAmzRequestIdHeader))
                 response.RequestId = context.ResponseData.GetHeaderValue(HeaderKeys.XAmzRequestIdHeader);
             if (context.ResponseData.IsHeaderPresent(HeaderKeys.XAmzId2Header))
                 response.Id2 = context.ResponseData.GetHeaderValue(HeaderKeys.XAmzId2Header);
 
-            if ((int)context.ResponseData.StatusCode >= 500)
+            if ((int)statusCode >= 500)
                 response.Type = ErrorType.Receiver;
-            else if ((int)context.ResponseData.StatusCode >= 400)
+            else if ((int)statusCode >= 400)
                 response.Type = ErrorType.Sender;
             else
                 response.Type = ErrorType.Unknown;
@@ -107,9 +109,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
                         }
                     }
                 }
-                catch
+                catch (Exception e)
                 {
                     // Error response was not XML
+                    response.ParsingException = e;
                 }
             }
 
@@ -134,19 +137,10 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
     public class S3ErrorResponse : ErrorResponse
     {
-        private string resource;
-        private string id2;
+        public string Resource { get; set; }
 
-        public string Resource
-        {
-            get { return resource; }
-            set { resource = value; }
-        }
+        public string Id2 { get; set; }
 
-        public string Id2
-        {
-            get { return id2; }
-            set { id2 = value; }
-        }
+        public Exception ParsingException { get; set; }
     }
 }

--- a/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/UploadPartResponseUnmarshaller.cs
+++ b/AWSSDK_DotNet35/Amazon.S3/Model/Internal/MarshallTransformations/UploadPartResponseUnmarshaller.cs
@@ -48,14 +48,7 @@ namespace Amazon.S3.Model.Internal.MarshallTransformations
 
             return;
         }
-        
-        public override AmazonServiceException UnmarshallException(XmlUnmarshallerContext context, Exception innerException, HttpStatusCode statusCode)
-        {
-            S3ErrorResponse errorResponse = S3ErrorResponseUnmarshaller.Instance.Unmarshall(context);
 
-            return new AmazonS3Exception(errorResponse.Message, innerException, errorResponse.Type, errorResponse.Code, errorResponse.RequestId, statusCode, errorResponse.Id2);
-        }
-        
         private static UploadPartResponseUnmarshaller _instance;
 
         public static UploadPartResponseUnmarshaller Instance

--- a/AWSSDK_DotNet35/Amazon.Util/AWSConfigs.Models.cs
+++ b/AWSSDK_DotNet35/Amazon.Util/AWSConfigs.Models.cs
@@ -86,7 +86,8 @@ namespace Amazon.Util
             Region = Choose(Region, root.Region);
             ProfileName = Choose(ProfileName, root.ProfileName);
             ProfilesLocation = Choose(ProfilesLocation, root.ProfilesLocation);
-            CorrectForClockSkew = root.CorrectForClockSkew;
+            if (root.CorrectForClockSkew.HasValue)
+                CorrectForClockSkew = root.CorrectForClockSkew.Value;
 #endif
         }
 

--- a/AWSSDK_DotNet35/Amazon.Util/AWSSDKUtils.cs
+++ b/AWSSDK_DotNet35/Amazon.Util/AWSSDKUtils.cs
@@ -41,7 +41,7 @@ namespace Amazon.Util
         internal const string DefaultRegion = "us-east-1";
         internal const string DefaultGovRegion = "us-gov-west-1";
 
-        internal const string SDKVersionNumber = "2.3.25.0";
+        internal const string SDKVersionNumber = "2.3.26.0";
 
         internal const int DefaultMaxRetry = 3;
         private const int DefaultConnectionLimit = 50;

--- a/AWSSDK_DotNet35/Properties/AssemblyInfo.cs
+++ b/AWSSDK_DotNet35/Properties/AssemblyInfo.cs
@@ -54,8 +54,8 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.25.0")]
-[assembly: AssemblyFileVersion("2.3.25.0")]
+[assembly: AssemblyVersion("2.3.26.0")]
+[assembly: AssemblyFileVersion("2.3.26.0")]
 
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Security.AllowPartiallyTrustedCallers]

--- a/AWSSDK_DotNet45/Properties/AssemblyInfo.cs
+++ b/AWSSDK_DotNet45/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.25.0")]
-[assembly: AssemblyFileVersion("2.3.25.0")]
+[assembly: AssemblyVersion("2.3.26.0")]
+[assembly: AssemblyFileVersion("2.3.26.0")]
 
 [assembly: System.CLSCompliant(true)]
 [assembly: System.Security.AllowPartiallyTrustedCallers]

--- a/AWSSDK_Portable/AWSConfigs.portable.cs
+++ b/AWSSDK_Portable/AWSConfigs.portable.cs
@@ -36,5 +36,10 @@ namespace Amazon
         {
             return null;
         }
+
+        internal static bool XmlSectionExists(string sectionName)
+        {
+            return false;
+        }
     }
 }

--- a/AWSSDK_Portable/Properties/AssemblyInfo.cs
+++ b/AWSSDK_Portable/Properties/AssemblyInfo.cs
@@ -24,8 +24,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.25.0")]
-[assembly: AssemblyFileVersion("2.3.25.0")]
+[assembly: AssemblyVersion("2.3.26.0")]
+[assembly: AssemblyFileVersion("2.3.26.0")]
 [assembly: ComVisible(false)]
 
 [assembly: System.CLSCompliant(true)]

--- a/AWSSDK_WP8/AWSConfigs.wp8.cs
+++ b/AWSSDK_WP8/AWSConfigs.wp8.cs
@@ -36,5 +36,10 @@ namespace Amazon
         {
             return null;
         }
+
+        internal static bool XmlSectionExists(string sectionName)
+        {
+            return false;
+        }
     }
 }

--- a/AWSSDK_WP8/Properties/AssemblyInfo.cs
+++ b/AWSSDK_WP8/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Resources;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.3.25.0")]
-[assembly: AssemblyFileVersion("2.3.25.0")]
+[assembly: AssemblyVersion("2.3.26.0")]
+[assembly: AssemblyFileVersion("2.3.26.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 
 [assembly: System.CLSCompliant(false)]

--- a/AWSSDK_WinRT/AWSConfigs.winrt.cs
+++ b/AWSSDK_WinRT/AWSConfigs.winrt.cs
@@ -36,5 +36,10 @@ namespace Amazon
         {
             return null;
         }
+
+        internal static bool XmlSectionExists(string sectionName)
+        {
+            return false;
+        }
     }
 }

--- a/AWSSDK_WinRT/Properties/AssemblyInfo.cs
+++ b/AWSSDK_WinRT/Properties/AssemblyInfo.cs
@@ -24,8 +24,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.25.0")]
-[assembly: AssemblyFileVersion("2.3.25.0")]
+[assembly: AssemblyVersion("2.3.26.0")]
+[assembly: AssemblyFileVersion("2.3.26.0")]
 [assembly: ComVisible(false)]
 
 [assembly: System.CLSCompliant(true)]

--- a/ServiceClientGenerator/Program.cs
+++ b/ServiceClientGenerator/Program.cs
@@ -12,7 +12,7 @@ using ServiceClientGenerator.Generators;
 
 namespace ServiceClientGenerator
 {
-    class Program
+    public class Program
     {
         static int Main(string[] args)
         {
@@ -96,7 +96,7 @@ namespace ServiceClientGenerator
         /// <param name="manifestPath">Path to the manifest file to pull basic info from</param>
         /// <param name="modelsFolder">Path to the service models to be parsed</param>
         /// <returns></returns>
-        static IEnumerable<GeneratorConfig> LoadGeneratorConfigs(string manifestPath, string modelsFolder)
+        public static IEnumerable<GeneratorConfig> LoadGeneratorConfigs(string manifestPath, string modelsFolder)
         {
             JsonData document;
             using (StreamReader reader = new StreamReader(manifestPath))

--- a/ServiceModels/elastictranscoder-2012-09-25.normal.json
+++ b/ServiceModels/elastictranscoder-2012-09-25.normal.json
@@ -921,7 +921,7 @@
     },
     "AudioCodec":{
       "type":"string",
-      "pattern":"(^AAC$)|(^vorbis$)|(^mp3$)"
+      "pattern":"(^AAC$)|(^vorbis$)|(^mp3$)|(^mp2$)"
     },
     "AudioCodecOptions":{
       "type":"structure",
@@ -942,7 +942,7 @@
       "members":{
         "Codec":{
           "shape":"AudioCodec",
-          "documentation":"<p>The audio codec for the output file. Valid values include <code>aac</code>, <code>mp3</code>, and <code>vorbis</code>.</p>"
+          "documentation":"<p>The audio codec for the output file. Valid values include <code>aac</code>, <code>mp2</code>, <code>mp3</code>, and <code>vorbis</code>.</p>"
         },
         "SampleRate":{
           "shape":"AudioSampleRate",
@@ -1304,7 +1304,7 @@
         },
         "Container":{
           "shape":"PresetContainer",
-          "documentation":"<p>The container type for the output file. Valid values include <code>fmp4</code>, <code>mp3</code>, <code>mp4</code>, <code>ogg</code>, <code>ts</code>, and <code>webm</code>.</p>"
+          "documentation":"<p>The container type for the output file. Valid values include <code>flv</code>, <code>fmp4</code>, <code>gif</code>, <code>mp3</code>, <code>mp4</code>, <code>mpg</code>, <code>ogg</code>, <code>ts</code>, and <code>webm</code>.</p>"
         },
         "Video":{
           "shape":"VideoParameters",
@@ -1671,6 +1671,10 @@
         "Encryption":{
           "shape":"Encryption",
           "documentation":"<p>The encryption settings, if any, that you want Elastic Transcoder to apply to your output files. If you choose to use encryption, you must specify a mode to use. If you choose not to use encryption, Elastic Transcoder will write an unencrypted file to your Amazon S3 bucket.</p>"
+        },
+        "AppliedColorSpaceConversion":{
+          "shape":"String",
+          "documentation":"<p>If Elastic Transcoder used a preset with a <code>ColorSpaceConversionMode</code> to transcode the output file, the <code>AppliedColorSpaceConversion</code> parameter shows the conversion used. If no <code>ColorSpaceConversionMode</code> was defined in the preset, this parameter will not be included in the job response.</p>"
         }
       },
       "documentation":"<p><important>Outputs recommended instead.</important>If you specified one output for a job, information about that output. If you specified multiple outputs for a job, the <code>Output</code> object lists information about the first output. This duplicates the information that is listed for the first output in the <code>Outputs</code> object.</p>"
@@ -2093,7 +2097,7 @@
         },
         "Container":{
           "shape":"PresetContainer",
-          "documentation":"<p>The container type for the output file. Valid values include <code>fmp4</code>, <code>mp3</code>, <code>mp4</code>, <code>ogg</code>, <code>ts</code>, and <code>webm</code>.</p>"
+          "documentation":"<p>The container type for the output file. Valid values include <code>flv</code>, <code>fmp4</code>, <code>gif</code>, <code>mp3</code>, <code>mp4</code>, <code>mpg</code>, <code>ogg</code>, <code>ts</code>, and <code>webm</code>.</p>"
         },
         "Audio":{
           "shape":"AudioParameters",
@@ -2116,7 +2120,7 @@
     },
     "PresetContainer":{
       "type":"string",
-      "pattern":"(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^ogg$)|(^fmp4$)"
+      "pattern":"(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^ogg$)|(^fmp4$)|(^mpg$)|(^flv$)|(^gif$)"
     },
     "PresetType":{
       "type":"string",
@@ -2550,26 +2554,26 @@
     },
     "VideoCodec":{
       "type":"string",
-      "pattern":"(^H\\.264$)|(^vp8$)"
+      "pattern":"(^H\\.264$)|(^vp8$)|(^mpeg2$)|(^gif$)"
     },
     "VideoParameters":{
       "type":"structure",
       "members":{
         "Codec":{
           "shape":"VideoCodec",
-          "documentation":"<p>The video codec for the output file. Valid values include <code>H.264</code> and <code>vp8</code>. You can only specify <code>vp8</code> when the container type is <code>webm</code>.</p>"
+          "documentation":"<p>The video codec for the output file. Valid values include <code>gif</code>, <code>H.264</code>, <code>mpeg2</code>, and <code>vp8</code>. You can only specify <code>vp8</code> when the container type is <code>webm</code>, <code>gif</code> when the container type is <code>gif</code>, and <code>mpeg2</code> when the container type is <code>mpg</code>.</p>"
         },
         "CodecOptions":{
           "shape":"CodecOptions",
-          "documentation":"<p> <b>Profile</b> </p> <p>The H.264 profile that you want to use for the output file. Elastic Transcoder supports the following profiles:</p> <ul> <li> <code>baseline</code>: The profile most commonly used for videoconferencing and for mobile applications.</li> <li> <code>main</code>: The profile used for standard-definition digital TV broadcasts.</li> <li> <code>high</code>: The profile used for high-definition digital TV broadcasts and for Blu-ray discs.</li> </ul> <p> <b>Level (H.264 Only)</b> </p> <p>The H.264 level that you want to use for the output file. Elastic Transcoder supports the following levels:</p> <p><code>1</code>, <code>1b</code>, <code>1.1</code>, <code>1.2</code>, <code>1.3</code>, <code>2</code>, <code>2.1</code>, <code>2.2</code>, <code>3</code>, <code>3.1</code>, <code>3.2</code>, <code>4</code>, <code>4.1</code></p> <p> <b>MaxReferenceFrames (H.264 Only)</b> </p> <p>Applicable only when the value of Video:Codec is H.264. The maximum number of previously decoded frames to use as a reference for decoding future frames. Valid values are integers 0 through 16, but we recommend that you not use a value greater than the following:</p> <p> <code>Min(Floor(Maximum decoded picture buffer in macroblocks * 256 / (Width in pixels * Height in pixels)), 16)</code> </p> <p>where <i>Width in pixels</i> and <i>Height in pixels</i> represent either MaxWidth and MaxHeight, or Resolution. <i>Maximum decoded picture buffer in macroblocks</i> depends on the value of the <code>Level</code> object. See the list below. (A macroblock is a block of pixels measuring 16x16.) </p> <ul> <li>1 - 396</li> <li>1b - 396</li> <li>1.1 - 900</li> <li>1.2 - 2376</li> <li>1.3 - 2376</li> <li>2 - 2376</li> <li>2.1 - 4752</li> <li>2.2 - 8100</li> <li>3 - 8100</li> <li>3.1 - 18000</li> <li>3.2 - 20480</li> <li>4 - 32768</li> <li>4.1 - 32768</li> </ul> <p> <b>MaxBitRate</b> </p> <p>The maximum number of bits per second in a video buffer; the size of the buffer is specified by <code>BufferSize</code>. Specify a value between 16 and 62,500. You can reduce the bandwidth required to stream a video by reducing the maximum bit rate, but this also reduces the quality of the video.</p> <p> <b>BufferSize</b> </p> <p>The maximum number of bits in any x seconds of the output video. This window is commonly 10 seconds, the standard segment duration when you're using FMP4 or MPEG-TS for the container type of the output video. Specify an integer greater than 0. If you specify <code>MaxBitRate</code> and omit <code>BufferSize</code>, Elastic Transcoder sets <code>BufferSize</code> to 10 times the value of <code>MaxBitRate</code>.</p>"
+          "documentation":"<p> <b>Profile (H.264/VP8 Only)</b> </p> <p>The H.264 profile that you want to use for the output file. Elastic Transcoder supports the following profiles:</p> <ul> <li> <code>baseline</code>: The profile most commonly used for videoconferencing and for mobile applications.</li> <li> <code>main</code>: The profile used for standard-definition digital TV broadcasts.</li> <li> <code>high</code>: The profile used for high-definition digital TV broadcasts and for Blu-ray discs.</li> </ul> <p> <b>Level (H.264 Only)</b> </p> <p>The H.264 level that you want to use for the output file. Elastic Transcoder supports the following levels:</p> <p><code>1</code>, <code>1b</code>, <code>1.1</code>, <code>1.2</code>, <code>1.3</code>, <code>2</code>, <code>2.1</code>, <code>2.2</code>, <code>3</code>, <code>3.1</code>, <code>3.2</code>, <code>4</code>, <code>4.1</code></p> <p> <b>MaxReferenceFrames (H.264 Only)</b> </p> <p>Applicable only when the value of Video:Codec is H.264. The maximum number of previously decoded frames to use as a reference for decoding future frames. Valid values are integers 0 through 16, but we recommend that you not use a value greater than the following:</p> <p> <code>Min(Floor(Maximum decoded picture buffer in macroblocks * 256 / (Width in pixels * Height in pixels)), 16)</code> </p> <p>where <i>Width in pixels</i> and <i>Height in pixels</i> represent either MaxWidth and MaxHeight, or Resolution. <i>Maximum decoded picture buffer in macroblocks</i> depends on the value of the <code>Level</code> object. See the list below. (A macroblock is a block of pixels measuring 16x16.) </p> <ul> <li>1 - 396</li> <li>1b - 396</li> <li>1.1 - 900</li> <li>1.2 - 2376</li> <li>1.3 - 2376</li> <li>2 - 2376</li> <li>2.1 - 4752</li> <li>2.2 - 8100</li> <li>3 - 8100</li> <li>3.1 - 18000</li> <li>3.2 - 20480</li> <li>4 - 32768</li> <li>4.1 - 32768</li> </ul> <p> <b>MaxBitRate (Optional, H.264/MPEG2/VP8 only)</b> </p> <p>The maximum number of bits per second in a video buffer; the size of the buffer is specified by <code>BufferSize</code>. Specify a value between 16 and 62,500. You can reduce the bandwidth required to stream a video by reducing the maximum bit rate, but this also reduces the quality of the video.</p> <p> <b>BufferSize (Optional, H.264/MPEG2/VP8 only)</b> </p> <p>The maximum number of bits in any x seconds of the output video. This window is commonly 10 seconds, the standard segment duration when you're using FMP4 or MPEG-TS for the container type of the output video. Specify an integer greater than 0. If you specify <code>MaxBitRate</code> and omit <code>BufferSize</code>, Elastic Transcoder sets <code>BufferSize</code> to 10 times the value of <code>MaxBitRate</code>.</p> <p> <b>InterlacedMode (Optional, H.264/MPEG2 Only)</b> </p> <p>The interlace mode for the output video.</p> <p>Interlaced video is used to double the perceived frame rate for a video by interlacing two fields (one field on every other line, the other field on the other lines) so that the human eye registers multiple pictures per frame. Interlacing reduces the bandwidth required for transmitting a video, but can result in blurred images and flickering.</p> <p>Valid values include <code>Progressive</code> (no interlacing, top to bottom), <code>TopFirst</code> (top field first), <code>BottomFirst</code> (bottom field first), and <code>Auto</code>.</p> <p>If <code>InterlaceMode</code> is not specified, Elastic Transcoder uses <code>Progressive</code> for the output. If <code>Auto</code> is specified, Elastic Transcoder interlaces the output.</p> <p> <b>ColorSpaceConversionMode (Optional, H.264/MPEG2 Only)</b> </p> <p>The color space conversion Elastic Transcoder applies to the output video. Color spaces are the algorithms used by the computer to store information about how to render color. <code>Bt.601</code> is the standard for standard definition video, while <code>Bt.709</code> is the standard for high definition video.</p> <p>Valid values include <code>None</code>, <code>Bt709toBt601</code>, <code>Bt601toBt709</code>, and <code>Auto</code>.</p> <p>If you chose <code>Auto</code> for <code>ColorSpaceConversionMode</code> and your output is interlaced, your frame rate is one of <code>23.97</code>, <code>24</code>, <code>25</code>, <code>29.97</code>, <code>50</code>, or <code>60</code>, your <code>SegmentDuration</code> is null, and you are using one of the resolution changes from the list below, Elastic Transcoder applies the following color space conversions:</p> <ul> <li> <i>Standard to HD, 720x480 to 1920x1080</i> - Elastic Transcoder applies <code>Bt601ToBt709</code> </li> <li> <i>Standard to HD, 720x576 to 1920x1080</i> - Elastic Transcoder applies <code>Bt601ToBt709</code> </li> <li> <i>HD to Standard, 1920x1080 to 720x480</i> - Elastic Transcoder applies <code>Bt709ToBt601</code> </li> <li> <i>HD to Standard, 1920x1080 to 720x576</i> - Elastic Transcoder applies <code>Bt709ToBt601</code> </li> </ul> <note>Elastic Transcoder may change the behavior of the <code>ColorspaceConversionMode</code> <code>Auto</code> mode in the future. All outputs in a playlist must use the same <code>ColorSpaceConversionMode</code>.</note> <p>If you do not specify a <code>ColorSpaceConversionMode</code>, Elastic Transcoder does not change the color space of a file. If you are unsure what <code>ColorSpaceConversionMode</code> was applied to your output file, you can check the <code>AppliedColorSpaceConversion</code> parameter included in your job response. If your job does not have an <code>AppliedColorSpaceConversion</code> in its response, no <code>ColorSpaceConversionMode</code> was applied.</p> <p> <b>ChromaSubsampling</b> </p> <p>The sampling pattern for the chroma (color) channels of the output video. Valid values include <code>yuv420p</code> and <code>yuv422p</code>.</p> <p><code>yuv420p</code> samples the chroma information of every other horizontal and every other vertical line, <code>yuv422p</code> samples the color information of every horizontal line and every other vertical line.</p> <p> <b>LoopCount (Gif Only)</b> </p> <p>The number of times you want the output gif to loop. Valid values include <code>Infinite</code> and integers between <code>0</code> and <code>100</code>, inclusive.</p>"
         },
         "KeyframesMaxDist":{
           "shape":"KeyframesMaxDist",
-          "documentation":"<p>The maximum number of frames between key frames. Key frames are fully encoded frames; the frames between key frames are encoded based, in part, on the content of the key frames. The value is an integer formatted as a string; valid values are between 1 (every frame is a key frame) and 100000, inclusive. A higher value results in higher compression but may also discernibly decrease video quality.</p> <p>For <code>Smooth</code> outputs, the <code>FrameRate</code> must have a constant ratio to the <code>KeyframesMaxDist</code>. This allows <code>Smooth</code> playlists to switch between different quality levels while the file is being played.</p> <p>For example, an input file can have a <code>FrameRate</code> of 30 with a <code>KeyframesMaxDist</code> of 90. The output file then needs to have a ratio of 1:3. Valid outputs would have <code>FrameRate</code> of 30, 25, and 10, and <code>KeyframesMaxDist</code> of 90, 75, and 30, respectively.</p> <p>Alternately, this can be achieved by setting <code>FrameRate</code> to auto and having the same values for <code>MaxFrameRate</code> and <code>KeyframesMaxDist</code>.</p>"
+          "documentation":"<p>Applicable only when the value of Video:Codec is one of <code>H.264</code>, <code>MPEG2</code>, or <code>VP8</code>.</p> <p>The maximum number of frames between key frames. Key frames are fully encoded frames; the frames between key frames are encoded based, in part, on the content of the key frames. The value is an integer formatted as a string; valid values are between 1 (every frame is a key frame) and 100000, inclusive. A higher value results in higher compression but may also discernibly decrease video quality.</p> <p>For <code>Smooth</code> outputs, the <code>FrameRate</code> must have a constant ratio to the <code>KeyframesMaxDist</code>. This allows <code>Smooth</code> playlists to switch between different quality levels while the file is being played.</p> <p>For example, an input file can have a <code>FrameRate</code> of 30 with a <code>KeyframesMaxDist</code> of 90. The output file then needs to have a ratio of 1:3. Valid outputs would have <code>FrameRate</code> of 30, 25, and 10, and <code>KeyframesMaxDist</code> of 90, 75, and 30, respectively.</p> <p>Alternately, this can be achieved by setting <code>FrameRate</code> to auto and having the same values for <code>MaxFrameRate</code> and <code>KeyframesMaxDist</code>.</p>"
         },
         "FixedGOP":{
           "shape":"FixedGOP",
-          "documentation":"<p>Whether to use a fixed value for <code>FixedGOP</code>. Valid values are <code>true</code> and <code>false</code>:</p> <ul> <li> <code>true</code>: Elastic Transcoder uses the value of <code>KeyframesMaxDist</code> for the distance between key frames (the number of frames in a group of pictures, or GOP).</li> <li> <code>false</code>: The distance between key frames can vary.</li> </ul> <important><p><code>FixedGOP</code> must be set to <code>true</code> for <code>fmp4</code> containers.</p></important>"
+          "documentation":"<p>Applicable only when the value of Video:Codec is one of <code>H.264</code>, <code>MPEG2</code>, or <code>VP8</code>.</p> <p>Whether to use a fixed value for <code>FixedGOP</code>. Valid values are <code>true</code> and <code>false</code>:</p> <ul> <li> <code>true</code>: Elastic Transcoder uses the value of <code>KeyframesMaxDist</code> for the distance between key frames (the number of frames in a group of pictures, or GOP).</li> <li> <code>false</code>: The distance between key frames can vary.</li> </ul> <important><p><code>FixedGOP</code> must be set to <code>true</code> for <code>fmp4</code> containers.</p></important>"
         },
         "BitRate":{
           "shape":"VideoBitRate",


### PR DESCRIPTION
This release updates the Amazon Elastic Transcoder client for new conversion formats and corrects some issues reported recently in the SDK.